### PR TITLE
Add a skip baseenvcheck parameter

### DIFF
--- a/starts/starts-initial-check.sh
+++ b/starts/starts-initial-check.sh
@@ -13,7 +13,7 @@
 #
 #-----------------------------------------------------------------------
 #
-# Be carefull when editing this file, it is part of a bigger scripts!
+# Be careful when editing this file, it is part of a bigger scripts!
 #
 # Basescript - https://github.com/evertramos/basescript
 #
@@ -21,23 +21,28 @@
 
 # ----------------------------------------------------------------------
 # This function has one main objective:
-# 1. Check initial setup 
+# 1. Check initial setup
 #
 # You must inform the parameters below:
-# 1. [optional] Pid file name (default: )
+# 1. [optional] (default: ) Pid file name
+# 2. [optional] (default: false) Skip 'baseenvfile' check, which means it will not check
+# if there is an .env file at the root of your script
 #
 # ----------------------------------------------------------------------
 starts_initial_check()
 {
-    local LOCAL_PID_FILE
-    
+    local LOCAL_PID_FILE LOCAL_SKIP_BASE_ENV_FILE
+
     LOCAL_PID_FILE=${1:-$PID_FILE}
+    LOCAL_SKIP_BASE_ENV_FILE=${2:-false}
 
     # Check if docker is installed
     run_function checkdocker
 
-    # Check if there is an .env file in base folder
-    run_function checkbaseenvfile
+    if [[ ! "$LOCAL_SKIP_BASE_ENV_FILE" == true ]]; then
+      # Check if there is an .env file in base folder
+      run_function checkbaseenvfile
+    fi
 
     # Check if you are already running an instance of this Script
     run_function check_running_script $LOCAL_PID_FILE


### PR DESCRIPTION
Add a skip local env file for projects that does not have a .env in the root of the calling script