### PR TITLE
Update docker hub api to version 2

### DIFF
--- a/dockerhub/dockerhub-check-image-exists.sh
+++ b/dockerhub/dockerhub-check-image-exists.sh
@@ -40,13 +40,14 @@ dockerhub_check_image_exists()
  
     [[ "$DEBUG" == true ]] && echo "Checking if image '$LOCAL_IMAGE:$LOCAL_TAG' exists in docker hub"
 
+    #TOKEN=$(curl -s -H "Content-Type: application/json" -X POST -d '{"username": "'${UNAME_DOCKERHUB}'", "password": "'${UPASS_DOCKERHUB}'"}' https://hub.docker.com/v2/users/login/ | jq -r .token)
     # This command will filter the number versions and limited to one dot (.)
-    LOCAL_RESPONSE=$(curl --write-out '%{http_code}' --silent --output /dev/null https://index.docker.io/v1/repositories/$LOCAL_IMAGE/tags/$LOCAL_TAG)
-    # LOCAL_RESPONSE=$(curl --silent -f -lSL https://index.docker.io/v1/repositories/$LOCAL_IMAGE/tags/$LOCAL_TAG >&1)
-
+    LOCAL_RESPONSE=$(curl --write-out '%{http_code}' --silent --output /dev/null https://hub.docker.com/v2/repositories/$LOCAL_IMAGE/tags/$LOCAL_TAG/)
+    
     if [[ $LOCAL_RESPONSE == "200" ]]; then
         DOCKERHUB_IMAGE_EXISTS=true
     else
         DOCKERHUB_IMAGE_EXISTS=false
     fi
 }
+

--- a/dockerhub/dockerhub-list-tags.sh
+++ b/dockerhub/dockerhub-list-tags.sh
@@ -41,9 +41,15 @@ dockerhub_list_tags()
     [[ "$DEBUG" == true ]] && echo "Listing tags from docker hub for image '$LOCAL_IMAGE'"
 
     # This command will filter the number versions and limited to one dot (.) and two versions such as 0.1 or all versions if LOCAL_GET_TWO_DIGITS_VERSIONS is set to false
+    # if [[ "$LOCAL_GET_TWO_DIGITS_VERSIONS" == true ]]; then
+    #     DOCKERHUB_LIST_TAGS=($(wget -q https://registry.hub.docker.com/v2/repositories/$LOCAL_IMAGE/tags -O - | sed -e 's/[][]//g' -e 's/"//g' -e 's/ //g' | tr '}' '\n'  | awk -F: '{print $3}' | grep '^[0-9]' | grep -v '-' | grep -v '\.[0-9]\.'))
+    # else
+    #     DOCKERHUB_LIST_TAGS=($(wget -q https://registry.hub.docker.com/v2/repositories/$LOCAL_IMAGE/tags -O - | sed -e 's/[][]//g' -e 's/"//g' -e 's/ //g' | tr '}' '\n'  | awk -F: '{print $3}' | grep '^[0-9]' | grep -v '-'))
+    # fi
+
     if [[ "$LOCAL_GET_TWO_DIGITS_VERSIONS" == true ]]; then
-        DOCKERHUB_LIST_TAGS=($(wget -q https://registry.hub.docker.com/v1/repositories/$LOCAL_IMAGE/tags -O - | sed -e 's/[][]//g' -e 's/"//g' -e 's/ //g' | tr '}' '\n'  | awk -F: '{print $3}' | grep '^[0-9]' | grep -v '-' | grep -v '\.[0-9]\.'))
+        DOCKERHUB_LIST_TAGS=($(curl -L -s "https://registry.hub.docker.com/v2/repositories/$LOCAL_IMAGE/tags?page_size=1024"|jq '."results"[]["name"]' | sed 's/"//g' | sed 's/\.[^.]*$//'))
     else
-        DOCKERHUB_LIST_TAGS=($(wget -q https://registry.hub.docker.com/v1/repositories/$LOCAL_IMAGE/tags -O - | sed -e 's/[][]//g' -e 's/"//g' -e 's/ //g' | tr '}' '\n'  | awk -F: '{print $3}' | grep '^[0-9]' | grep -v '-'))
+        DOCKERHUB_LIST_TAGS=($(curl -L -s "https://registry.hub.docker.com/v2/repositories/$LOCAL_IMAGE/tags?page_size=1024"|jq '."results"[]["name"]' | sed 's/"//g'))
     fi
 }

--- a/file/file-comment-line-with-string.sh
+++ b/file/file-comment-line-with-string.sh
@@ -52,5 +52,11 @@ file_comment_line_with_string()
     # Allows 'sudo' to run this function if destination path it's not owned by the current user
     [[ "$LOCAL_ALLOW_RUN_WITH_SUDO" == true ]] && ! system_check_user_folder_owner ${LOCAL_FULL_FILE_PATH%/*} && LOCAL_RUN_WITH_SUDO=sudo
 
-    $LOCAL_RUN_WITH_SUDO sed -i '/'"$LOCAL_STRING"'/s/^/'"$LOCAL_COMMENT_MARK"'/g' "$LOCAL_FULL_FILE_PATH"
-}
+    # check if machine is Mac to update sed command
+    if [ "$(uname)" == "Darwin" ]; then 
+        $LOCAL_RUN_WITH_SUDO sed -i '' -e '/'"$LOCAL_STRING"'/s/^/'"$LOCAL_COMMENT_MARK"'/g' "$LOCAL_FULL_FILE_PATH"
+    else 
+        $LOCAL_RUN_WITH_SUDO sed -i '/'"$LOCAL_STRING"'/s/^/'"$LOCAL_COMMENT_MARK"'/g' "$LOCAL_FULL_FILE_PATH"   
+    fi
+
+    }


### PR DESCRIPTION
Fixes:
- dockerhub_check_image_exists: updated repo url with v2 instead of v1 which deprecated.
- dockerhub_list_tags: updated repo url with v2 (instead of v1 which deprecated) but with considering LOCAL_GET_TWO_DIGITS_VERSIONS.
- file_comment_line_with_string: updated sed option to be supported by Mac machine

All these fixes have been tested on Mac v 12.5.1 (21G83) and Ubuntu 20.04.5 LTS